### PR TITLE
fix(commands-wrappper): run original command if 'executionContext' is not specified

### DIFF
--- a/lib/commands-wrapper.js
+++ b/lib/commands-wrapper.js
@@ -37,7 +37,11 @@ module.exports = (browser) => {
         const originCommand = browser[commandName].bind(browser);
 
         browser.addCommand(commandName, (...args) => {
-            const dataTransfer = browser.executionContext.hermioneCtx;
+            const dataTransfer = _.get(browser, 'executionContext.hermioneCtx');
+
+            if (!dataTransfer) {
+                return originCommand(...args);
+            }
 
             dataTransfer.commandList = dataTransfer.commandList || [{
                 name: 'root',


### PR DESCRIPTION
With hermione@0.85.0 this plugin started to throw an error: `TypeError: Cannot read property 'hermioneCtx' of undefined`. The problem is that in hermione@0.85.0 we executing commands: `scroll and `moveToObject` in order to move the cursor to the 0,0 position without any execution context (before any `beforeEach` hook).